### PR TITLE
Add action to automatically merge dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,8 @@
+name: Automerge Dependabot PRs
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    uses: swup/.github/.github/workflows/dependabot-automerge.yml@master
+    secrets: inherit

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,6 +1,7 @@
 name: Automerge Dependabot PRs
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   auto-merge:


### PR DESCRIPTION
**Description**

So this is the first _real_ test (pending ejs PR from dependabot should be merged automatically). I fear the other tests weren't valid as the dependabot PRs had already been merged manually before we added this action.

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
