### PR TITLE
Remove `workflow_dispatch` trigger from dependabot-automerge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,7 +1,6 @@
 name: Automerge Dependabot PRs
 on:
   pull_request:
-  workflow_dispatch:
 
 jobs:
   auto-merge:


### PR DESCRIPTION
The underlying action only works with `on: pull_request` anyways

@daun I'd propose to wait until the next wave of dependabot PRs. If it is being merged automatically here, we can implement the action for all other packages, as well.

**Description**

<!--
Clear and concise description of the proposed changes, as well as a convincing reason for adding them to swup.
-->

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
